### PR TITLE
'Skip to' usability enhancements

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,17 +13,29 @@ require([
 ) {
 
   /**
-   * Focus the search widget when someone clicks
+   * Focus the search widget when someone clicks or uses the 'spacebar' or 'enter' keys
    * the "Skip to search" skip link.
    */
+  document.getElementById('skip-search').addEventListener('keypress', function (e) {
+    if (e.keyCode == 13 || e.keyCode == 32  || e.charCode == 32) {
+      search.focus();
+    }
+  });
+
   document.getElementById('skip-search').addEventListener('click', function (e) {
     search.focus();
   });
 
   /**
    * Focus the first focusable item in the list
-   * when someone clicks the "Skip to list" link
+   * when someone clicks or uses the 'spacebar' or 'enter' keys to the "Skip to list" link
    */
+  document.getElementById('skip-list').addEventListener('keypress', function (e) {
+    if (e.keyCode == 13 || e.keyCode == 32  || e.charCode == 32) {
+      focusFirstItemInList();
+    }
+  });
+
   document.getElementById('skip-list').addEventListener('click', function (e) {
     focusFirstItemInList();
   });

--- a/style.css
+++ b/style.css
@@ -55,6 +55,7 @@ body {
 
 .skip {
   color: white;
+  background-color: #002C61;
   position: fixed;
   top: 0;
   left: 0;
@@ -76,8 +77,9 @@ body {
   clip: auto;
 }
 
-.skip:hover, .skip:focus {
-  background-color: #002C61;
+.skip:hover, .skip:active {
+  background-color: rgba(255,255,255,.3);
+  color: #002C61;
 }
 
 #list {


### PR DESCRIPTION
1. Add a keypress event listener to the 'Skip to' links, so a user can **interact with the 'Skip to' links by hitting the `spacebar` or `enter` keys** (in addition to clicking). The update has been tested in Chrome, Firefox, and IE.

2. Update the 'Skip to' styles `:hover` and `:active` classes

**Skip to style (unchanged):**  
![Skip to style, unchanged](https://user-images.githubusercontent.com/5023024/31581160-64c90d74-b129-11e7-9396-02ea793ab14b.png)  


**Before changes to `:hover` and `:active` classes:**  
![Before PR with text not visible](https://user-images.githubusercontent.com/5023024/31581148-d5857c24-b128-11e7-8454-5eedb2445a40.png)


**After changes to `:hover` and `:active` classes:**  
![After PR with text visible](https://user-images.githubusercontent.com/5023024/31581150-e67bb818-b128-11e7-8272-ba9919205cff.png)  